### PR TITLE
EOSX: default parameter value too low, results in issues when not set in the parfile explicity

### DIFF
--- a/EOSX/param.ccl
+++ b/EOSX/param.ccl
@@ -36,7 +36,7 @@ CCTK_REAL rho_max "Validity region: max density" STEERABLE=RECOVER
 CCTK_REAL rho_min "Validity region: min density" STEERABLE=RECOVER
 {
   (0:* :: ""
-} 1.0e-100
+} 1.0e-40
 
 CCTK_REAL eps_max "Validity region: max internal specific energy" STEERABLE=RECOVER
 {


### PR DESCRIPTION
The rho_min parameter, originally set to 1e-100, causes buggy evolution with Noble C2P if not explicitly set correctly in the parfile. To avoid this, the default parameter is now set to 1e-40, which does not result in buggy evolution (tested with Balsara 3).