### PR TITLE
EOSX: dummy call for mu_lepton for ideal gas EOS

### DIFF
--- a/AsterAnalysis/src/analysis_mhd.cxx
+++ b/AsterAnalysis/src/analysis_mhd.cxx
@@ -79,17 +79,8 @@ extern "C" void AsterAnalysis_MHD(CCTK_ARGUMENTS) {
         B_norm(p.I) = sqrt(B2big);
 
         /* cell-centered A^i and A_i */
-
-        const vec<CCTK_REAL, 3> A_low([&](int i) ARITH_INLINE -> CCTK_REAL {
-          switch (i) {
-          case 0:
-            return calc_avg_e2c<0>(gf_Avec(0), p);
-          case 1:
-            return calc_avg_e2c<1>(gf_Avec(1), p);
-          default:
-            return calc_avg_e2c<2>(gf_Avec(2), p);
-          }
-        });
+        const vec<CCTK_REAL, 3> A_low(
+            [&](int i) ARITH_INLINE { return calc_avg_e2c(gf_Avec(i), p, i); });
 
         const vec<CCTK_REAL, 3> A_up = calc_contraction(ug_avg, A_low);
 

--- a/AsterAnalysis/src/analysis_mhd.cxx
+++ b/AsterAnalysis/src/analysis_mhd.cxx
@@ -79,8 +79,18 @@ extern "C" void AsterAnalysis_MHD(CCTK_ARGUMENTS) {
         B_norm(p.I) = sqrt(B2big);
 
         /* cell-centered A^i and A_i */
-        const vec<CCTK_REAL, 3> A_low(
-            [&](int i) ARITH_INLINE { return calc_avg_e2c(gf_Avec(i), p, i); });
+
+        const vec<CCTK_REAL, 3> A_low([&](int i) ARITH_INLINE -> CCTK_REAL {
+          switch (i) {
+          case 0:
+            return calc_avg_e2c<0>(gf_Avec(0), p);
+          case 1:
+            return calc_avg_e2c<1>(gf_Avec(1), p);
+          default:
+            return calc_avg_e2c<2>(gf_Avec(2), p);
+          }
+        });
+
         const vec<CCTK_REAL, 3> A_up = calc_contraction(ug_avg, A_low);
 
         A_norm(p.I) = sqrt(calc_contraction(A_low, A_up));

--- a/AsterUtils/src/aster_interp.hxx
+++ b/AsterUtils/src/aster_interp.hxx
@@ -69,12 +69,12 @@ calc_avg_e2e(const GF3D2<const T> &gf, const PointDesc &p) {
 
 // Second-order average of edge-centered grid functions (along dir) to cell
 // center
-template <int dir, typename T>
+template <typename T>
 CCTK_DEVICE CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline T
-calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p) {
-  T gf_avg = 0;
-  constexpr int j = (dir == 0) ? 1 : ((dir == 1) ? 2 : 0);
-  constexpr int k = (dir == 0) ? 2 : ((dir == 1) ? 0 : 1);
+calc_avg_e2c(const GF3D2<const T> &gf, const PointDesc &p, const int dir) {
+  T gf_avg = 0.0;
+  const int j = (dir == 0) ? 1 : ((dir == 1) ? 2 : 0);
+  const int k = (dir == 0) ? 2 : ((dir == 1) ? 0 : 1);
   for (int dk = 0; dk < 2; ++dk) {
     for (int dj = 0; dj < 2; ++dj) {
       gf_avg += gf(p.I + p.DI[j] * dj + p.DI[k] * dk);

--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -124,11 +124,7 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType *eos_1p,
       const CCTK_REAL gm1 = eos_1p->gm1_from_valid_rho(rho_atm);
       temp_atm = eos_1p->temp_from_valid_gm1(gm1);
       temp_atm = std::max(eos_3p->rgtemp.min, temp_atm);
-      eps_atm = eos_1p->sed_from_valid_gm1(gm1);
-      eps_atm = std::max(eos_3p->eps_from_valid_rho_temp_ye(
-                             rho_atm, eos_3p->rgtemp.min, Ye_atmo),
-                         eps_atm);
-      temp_atm = eos_3p->temp_from_valid_rho_eps_ye(rho_atm, eps_atm, Ye_atmo);
+      eps_atm = eos_3p->eps_from_valid_rho_temp_ye(rho_atm, temp_atm, Ye_atmo);
       // eps_atm should be kept consistent with temp_atm, so we do not use
       // the setting below
       // eps_atm =

--- a/EOSX/src/eos_3p_idealgas/eos_3p_idealgas.hxx
+++ b/EOSX/src/eos_3p_idealgas/eos_3p_idealgas.hxx
@@ -21,28 +21,28 @@ public:
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       CCTK_REAL &eps,      ///< Specific internal energy \f$ \epsilon \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   eps_from_valid_rho_press_ye(
       const CCTK_REAL rho,   ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL press, ///< Pressure \f$ P \f$
       const CCTK_REAL ye     ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   csnd_from_valid_rho_eps_ye(
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       CCTK_REAL &eps,      ///< Specific internal energy \f$ \epsilon \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   temp_from_valid_rho_eps_ye(
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       CCTK_REAL &eps,      ///< Specific internal energy \f$ \epsilon \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
   press_derivs_from_valid_rho_eps_ye(
@@ -54,35 +54,35 @@ public:
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL eps, ///< Specific internal energy \f$ \epsilon \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   entropy_from_valid_rho_temp_ye(
       const CCTK_REAL rho,  ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL temp, ///< Temperature \f$ T \f$
       const CCTK_REAL ye    ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   entropy_from_valid_rho_eps_ye(
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL eps, ///< Specific internal energy \f$ \epsilon \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   eps_from_valid_rho_temp_ye(
       const CCTK_REAL rho,  ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL temp, ///< Temperature \f$ T \f$ in MeV
       const CCTK_REAL ye    ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   press_from_valid_rho_temp_ye(
       const CCTK_REAL rho,  ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL temp, ///< Temperature \f$ T \f$ in MeV
       const CCTK_REAL ye    ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
 
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   press_from_valid_rho_kappa_ye(const CCTK_REAL rho,
@@ -109,7 +109,13 @@ public:
   range_eps_from_valid_rho_ye(
       const CCTK_REAL rho, ///< Rest mass density  \f$ \rho \f$
       const CCTK_REAL ye   ///< Electron fraction \f$ Y_e \f$
-      ) const;
+  ) const;
+
+  // Note that the function below do not apply for ideal gas EOS
+  // They are used for testing nuX with toy problems
+  CCTK_HOST CCTK_DEVICE inline CCTK_REAL
+  mu_lepton_from_valid_rho_temp_ye(const CCTK_REAL rho, const CCTK_REAL temp,
+                                   const CCTK_REAL ye) const;
 };
 
 CCTK_HOST
@@ -232,6 +238,15 @@ CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline eos_3p::range
 eos_3p_idealgas::range_eps_from_valid_rho_ye(const CCTK_REAL rho,
                                              const CCTK_REAL ye) const {
   return rgeps;
+}
+
+// Note that the function below do not apply for ideal gas EOS
+// They are used for testing nuX with toy problems
+CCTK_HOST CCTK_DEVICE inline CCTK_REAL
+eos_3p_idealgas::mu_lepton_from_valid_rho_temp_ye(const CCTK_REAL rho,
+                                                  const CCTK_REAL temp,
+                                                  const CCTK_REAL ye) const {
+  return 0.0;
 }
 
 } // namespace EOSX


### PR DESCRIPTION
Since nuX_M1 tests use ideal gas EOS, we also require a dummy call to compute mu_lepton