### PR TITLE
AsterX: calling FillPatch_Sync on all levels

### DIFF
--- a/AsterX/src/sync.cxx
+++ b/AsterX/src/sync.cxx
@@ -26,16 +26,16 @@ void ApplyOuterBC(CCTK_ARGUMENTS, const std::vector<int> &groups) {
       const int ntls = groupdata.mfab.size();
       const int sync_tl = ntls > 1 ? ntls - 1 : ntls;
 
-      if (leveldata.level == 0) {
-        // Copy from adjacent boxes on same level and apply boundary conditions
-        for (int tl = 0; tl < sync_tl; ++tl) {
-          tasks1.submit_serially([&tasks2, &leveldata, &groupdata, tl]() {
-            FillPatch_Sync(tasks2, groupdata, *groupdata.mfab.at(tl),
-                           ghext->patchdata.at(leveldata.patch)
-                               .amrcore->Geom(leveldata.level));
-          });
-        } // for tl
-      }
+      // Copy from adjacent boxes on same level and apply boundary conditions
+      // Even though this introduces additional communication, it makes the code
+      // compatible with symmetries.
+      for (int tl = 0; tl < sync_tl; ++tl) {
+        tasks1.submit_serially([&tasks2, &leveldata, &groupdata, tl]() {
+          FillPatch_Sync(tasks2, groupdata, *groupdata.mfab.at(tl),
+                         ghext->patchdata.at(leveldata.patch)
+                             .amrcore->Geom(leveldata.level));
+        });
+      } // for tl
     });
   } // for gi
 


### PR DESCRIPTION
We call `FillPatch_Sync` on all levels to ensure consistency with symmetric setups.
Although this introduces additional communication, it is worth the cost.