### PR TITLE
AsterX: add option to freeze evolution

### DIFF
--- a/AsterX/param.ccl
+++ b/AsterX/param.ccl
@@ -88,6 +88,10 @@ BOOLEAN unit_test "turn on all the unit tests if set to yes" STEERABLE=always
 {
 } no
 
+BOOLEAN freeze_evolution "Freeze AsterX evolution while retaining initialization and poststep primitive updates" STEERABLE=always
+{
+} no
+
 CCTK_INT unit_test_repetitions "Number of times each unit test should be repeated" STEERABLE=always 
 {
   0:* :: "Must be no smaller than 0"

--- a/AsterX/schedule.ccl
+++ b/AsterX/schedule.ccl
@@ -279,6 +279,15 @@ if (use_deriv_shock_detector)
   } "Detect shocks, flag for low-order recon fallback"
 }
 
+if(freeze_evolution) {
+SCHEDULE AsterX_FreezeEvolutionRHS IN ODESolvers_RHS
+{
+  LANG: C
+  WRITES: rhs_vector(interior)
+  WRITES: Avec_x_rhs(interior) Avec_y_rhs(interior) Avec_z_rhs(interior) Psi_rhs(interior)
+} "Set AsterX RHS to zero when freeze_evolution is enabled"
+}
+
 if(!freeze_evolution) {
 
 SCHEDULE GROUP AsterX_RHSGroup IN ODESolvers_RHS

--- a/AsterX/schedule.ccl
+++ b/AsterX/schedule.ccl
@@ -279,6 +279,8 @@ if (use_deriv_shock_detector)
   } "Detect shocks, flag for low-order recon fallback"
 }
 
+if(!freeze_evolution) {
+
 SCHEDULE GROUP AsterX_RHSGroup IN ODESolvers_RHS
 {
 } "Calculate AsterX RHS"
@@ -423,3 +425,5 @@ if(add_dissipation)
     WRITES: Avec_x_rhs(interior) Avec_y_rhs(interior) Avec_z_rhs(interior) Psi_rhs(interior)
   } "Add KO dissipation"
 }
+
+} # end of if(!freeze_evolution)

--- a/AsterX/src/rhs.cxx
+++ b/AsterX/src/rhs.cxx
@@ -175,4 +175,41 @@ extern "C" void AsterX_RHS(CCTK_ARGUMENTS) {
   CalcRHSofPsi(CCTK_PASS_CTOC, gauge, lorenz_damp_fac);
 }
 
+extern "C" void AsterX_FreezeEvolutionRHS(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTSX_AsterX_FreezeEvolutionRHS;
+
+  grid.loop_int_device<1, 1, 1>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        densrhs(p.I) = 0.0;
+        momxrhs(p.I) = 0.0;
+        momyrhs(p.I) = 0.0;
+        momzrhs(p.I) = 0.0;
+        taurhs(p.I) = 0.0;
+        DYe_rhs(p.I) = 0.0;
+        DEntrhs(p.I) = 0.0;
+      });
+
+  grid.loop_int_device<1, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        Avec_x_rhs(p.I) = 0.0;
+      });
+  grid.loop_int_device<0, 1, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        Avec_y_rhs(p.I) = 0.0;
+      });
+  grid.loop_int_device<0, 0, 1>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        Avec_z_rhs(p.I) = 0.0;
+      });
+  grid.loop_int_device<0, 0, 0>(
+      grid.nghostzones,
+      [=] CCTK_DEVICE(const PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {
+        Psi_rhs(p.I) = 0.0;
+      });
+}
+
 } // namespace AsterX


### PR DESCRIPTION
Some of the nuX_M1 tests require AsterX to freeze evolution. This update allows to do so. By default, freeze_evolution is set to no. 