### PR TITLE
Con2PrimFactory: Use Algo::brent's failure flag

### DIFF
--- a/Con2PrimFactory/src/c2p_1DEntropy.hxx
+++ b/Con2PrimFactory/src/c2p_1DEntropy.hxx
@@ -351,19 +351,12 @@ c2p_1DEntropy::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
     return funcRoot_1DEntropy(Ssq, Bsq, BiSi, x, eos_3p, cv);
   };
 
-  // Important!
-  // Algo::brent terminates if the following accuracy is achieved
-  // abs(x - y) <= eps * min(abs(x), abs(y)),
-  // where x and y are the values of the bracket and
-  // eps = std::ldexp(1, -minbits) = 1 * 2^{-minbits}
-  // This should probably be changed in Algo::brent
-
-  // We want to set the tolerance to its correct parameter
+  // Algo::brent terminates once the bracket satisfies
+  //   abs(x - y) <= eps * min(abs(x), abs(y)),   eps = 2^{1-minbits}
+  // so express the requested tolerance in bits. The +1 accounts for the
+  // exponent offset, and reproduces the eps this code used to compute by hand.
   const CCTK_REAL log2 = std::log(2.0);
-  const CCTK_INT minbits = int(abs(std::log(tolerance)) / log2);
-  const CCTK_REAL tolerance_0 = std::ldexp(double(1.0), -minbits);
-  // Old code:
-  // const CCTK_INT minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
+  const CCTK_INT minbits = int(abs(std::log(tolerance)) / log2) + 1;
   const CCTK_INT maxiters = maxIterations;
 
   const CCTK_REAL f_a0 = fn(a);
@@ -372,7 +365,9 @@ c2p_1DEntropy::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
     status = ROOTSTAT::NOT_BRACKETED;
   }
 
-  auto result = Algo::brent(fn, a, b, minbits, maxiters, rep.iters);
+  bool root_failed;
+  auto result =
+      Algo::brent(fn, a, b, minbits, maxiters, rep.iters, root_failed);
 
   CCTK_REAL xEntropy_Sol = 0.5 * (result.first + result.second);
 
@@ -381,8 +376,7 @@ c2p_1DEntropy::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
   // Check solution and calculate primitives
   //  if (rep.iters < maxiters && abs(fn(xEntropy_Sol)) < tolerance) {
   /*
-  if (abs(result.first - result.second) <=
-      tolerance_0 * min(abs(result.first), abs(result.second))) {
+  if (!root_failed) {
     rep.status = c2p_report::SUCCESS;
     status = ROOTSTAT::SUCCESS;
   } else {
@@ -401,9 +395,7 @@ c2p_1DEntropy::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
   }
 
   const CCTK_REAL root_width = abs(result.first - result.second);
-  const CCTK_REAL strict_width_tol =
-      tolerance_0 * min(abs(result.first), abs(result.second));
-  if (root_width > strict_width_tol) {
+  if (root_failed) {
     bool accept_soft = false;
     if (soft_root_convergence) {
       const CCTK_REAL scale =

--- a/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
+++ b/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
@@ -395,19 +395,12 @@ c2p_1DPalenzuela::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
   // const CCTK_INT minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
   // const CCTK_INT maxiters = maxIterations;
 
-  // Important!
-  // Algo::brent terminates if the following accuracy is achieved
-  // abs(x - y) <= eps * min(abs(x), abs(y)),
-  // where x and y are the values of the bracket and
-  // eps = std::ldexp(1, -minbits) = 1 * 2^{-minbits}
-  // This should probably be changed in Algo::brent
-
-  // We want to set the tolerance to its correct parameter
+  // Algo::brent terminates once the bracket satisfies
+  //   abs(x - y) <= eps * min(abs(x), abs(y)),   eps = 2^{1-minbits}
+  // so express the requested tolerance in bits. The +1 accounts for the
+  // exponent offset, and reproduces the eps this code used to compute by hand.
   const CCTK_REAL log2 = std::log(2.0);
-  const CCTK_INT minbits = int(abs(std::log(tolerance)) / log2);
-  const CCTK_REAL tolerance_0 = std::ldexp(double(1.0), -minbits);
-  // Old code:
-  // const CCTK_INT minbits = std::numeric_limits<CCTK_REAL>::digits - 4;
+  const CCTK_INT minbits = int(abs(std::log(tolerance)) / log2) + 1;
   const CCTK_INT maxiters = maxIterations;
 
   CCTK_REAL qPalenzuela = cv.tau / cv.dens;
@@ -438,7 +431,9 @@ c2p_1DPalenzuela::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
     status = ROOTSTAT::NOT_BRACKETED;
   }
 
-  auto result = Algo::brent(fn, a, b, minbits, maxiters, rep.iters);
+  bool root_failed;
+  auto result =
+      Algo::brent(fn, a, b, minbits, maxiters, rep.iters, root_failed);
 
   // Legacy endpoint-preference selector kept for reference; below we use the
   // midpoint rule for xPalenzuela_Sol.
@@ -479,26 +474,14 @@ c2p_1DPalenzuela::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
     rep.adjust_cons = true;
   }
 
-  // General comment:
-  // One could think of expressing the following condition
-  // in a way that is "safe" against NaNs and infs. First, this only makes
-  // sense if we want these values to be considered as failures which should
-  // be treated as "not converged".
-  //
-  // inf: Since inf behaves like a large valid number nothing special needs
-  // to be done except of rewriting the argument of the if condition such that
-  // possible infs are present only on one side of the comparison, eg
-  // abs(difference)/abs(normalization) > tolerance_0
-  //
-  // NaN: If the argument of if (...) is NaN, it usually evaluates to false.
-  // Here, we would need to rewrite the logic a little bit.
-
-  // TODO: have an explicit check on max_iters, e.g.:
-  // if (rep.iters >= maxiters || abs(fn(xPalenzuela_Sol)) > tolerance) {
+  // `root_failed` covers both a bracket that never converged and one that ran
+  // out of iterations, so the max_iters check that used to be wanted here is
+  // no longer needed. It also avoids re-deriving brent's convergence test from
+  // its bracket, which was both a duplicate of the tolerance in Algo and
+  // awkward to make safe against NaN and inf operands. The soft-convergence
+  // fallback below is unchanged.
   const CCTK_REAL root_width = abs(result.first - result.second);
-  const CCTK_REAL strict_width_tol =
-      tolerance_0 * min(abs(result.first), abs(result.second));
-  if (root_width > strict_width_tol) {
+  if (root_failed) {
     bool accept_soft = false;
     if (soft_root_convergence) {
       const CCTK_REAL scale =


### PR DESCRIPTION
Companion to **EinsteinToolkit/CarpetX#398**, which fixes a set of bugs in `Algo`'s root finders. **These two need to land together** — that PR changes `Algo::brent`'s signature, and `Con2PrimFactory` is its only caller outside the `Algo` thorn.

## What changes

`Algo::brent` now reports failure through a `failed` out-parameter instead of by setting `iters = max_iters`, and its convergence criterion matches `boost::math::tools::eps_tolerance`, i.e. `eps = 2^(1-minbits)` rather than an unclamped `2^-minbits`.

Both solvers here re-derived brent's own convergence test from the returned bracket:

```cpp
const CCTK_REAL tolerance_0 = std::ldexp(1.0, -minbits);   // brent's OLD eps, hardcoded
const CCTK_REAL strict_width_tol =
    tolerance_0 * min(abs(result.first), abs(result.second));
if (root_width > strict_width_tol) { ... }
```

That is `eps_tolerance::operator()` copied inline against a hardcoded constant. After the tolerance fix it would be twice as strict as the criterion brent actually applies, and would start declaring failure on brackets brent considers converged. Asking brent instead removes the duplicate entirely — and with it the awkwardness the comment here noted about making that comparison safe against NaN and inf operands, and the `TODO` asking for an explicit `max_iters` check, since `failed` already covers both non-convergence and exhaustion.

The **soft-convergence fallback is untouched**. `root_width` is still computed and still drives `accept_soft`; only the strict test it falls back from changes. The `NOT_BRACKETED` pre-check that decides which failure gets reported is likewise unchanged.

## This is behaviour-preserving

Deriving `minbits` from the requested tolerance needs one more bit to ask for the same `eps` as before:

| `c2p_tol` | old `minbits` / `eps` | new `minbits` / `eps` | identical |
| --- | --- | --- | --- |
| 1e-8  | 26 / 1.490116e-08 | 27 / 1.490116e-08 | yes |
| 1e-10 (default) | 33 / 1.164153e-10 | 34 / 1.164153e-10 | yes |
| 1e-14 | 46 / 1.421085e-14 | 47 / 1.421085e-14 | yes |
| 1e-15 | 49 / 1.776357e-15 | 50 / 1.776357e-15 | yes |
| 1e-16 | 53 / 1.110223e-16 | 54 / 8.881784e-16 | no |

Only tolerances at or below 1e-16 differ, and those were asking for closer agreement than two distinct doubles can have — a criterion brent could never satisfy, so it burned its whole iteration budget instead. That is one of the bugs CarpetX#398 fixes.

Checked directly rather than only on paper: 20,000 brackets run through the old code at the old `minbits` and the new code at the new `minbits` returned bit-identical results and identical iteration counts.

## Testing

**This branch is based on `dev` but has not been built or tested against `dev`.** Please treat that as the main caveat.

The identical change was built and tested on the `main` lineage, where these two files are byte-identical to their upstream-`main` versions: `sim-debug` compiles, and `AsterX/Balsara1_shocktube_xdir_ppm_PalenzuelaC2P` reports `Number failed -> 0`. `dev` is 466 commits ahead of that checkout, and while `c2p_1DPalenzuela.hxx` and `c2p_1DEntropy.hxx` have been restructured since — the strict test now goes through the named `root_width` / `strict_width_tol` locals, and the soft-convergence path is new — the `Algo::brent` call site, the `tolerance_0` derivation and the stale comment block are unchanged, so the port is the same set of edits at different line numbers. CI on `dev` is the real check.
