### PR TITLE
AsterX: explicitly schedule AsterX_Con2PrimGroup AFTER ADMBaseX_SetADMVars

### DIFF
--- a/AsterX/schedule.ccl
+++ b/AsterX/schedule.ccl
@@ -192,7 +192,7 @@ SCHEDULE AsterX_Sync AT post_recover_variables BEFORE ODESolvers_PostStep AFTER 
   SYNC: saved_prims
 } "Synchronize"
 
-SCHEDULE GROUP AsterX_Con2PrimGroup IN ODESolvers_PostStep BEFORE TmunuBaseX_SetTmunuVars AFTER AsterX_Sync
+SCHEDULE GROUP AsterX_Con2PrimGroup IN ODESolvers_PostStep BEFORE TmunuBaseX_SetTmunuVars AFTER AsterX_Sync AFTER ADMBaseX_SetADMVars
 {
 } "Compute primitive variables"
 


### PR DESCRIPTION
Schedule Con2Prim after ADM variables are updated, i.e. ensure ADMBaseX_SetADMVars completes before AsterX_Con2PrimGroup, so primitive recovery uses the current metric, lapse, and shift