### PR TITLE
ID_TabEOS_HydroQuantities: fix GPU use-after-free in Ye initialization

### DIFF
--- a/ID_TabEOS_HydroQuantities/src/ID_TabEOS_HydroQuantities.cxx
+++ b/ID_TabEOS_HydroQuantities/src/ID_TabEOS_HydroQuantities.cxx
@@ -28,10 +28,10 @@ extern "C" void ID_TabEOS_HydroQuantities_initial_Y_e(CCTK_ARGUMENTS) {
   auto eos_3p_tab3d = global_eos_3p_tab3d;
 
   // Open the Y_e file, which should countain Y_e(rho) for the EOS table slice
-  FILE *Y_e_file = fopen(Y_e_filename, "r");
+  FILE *const Y_e_file = fopen(Y_e_filename, "r");
 
   // Check if everything is OK with the file
-  if ((Y_e_file = fopen(Y_e_filename, "r")) == NULL) {
+  if (Y_e_file == NULL) {
     CCTK_VError(__LINE__, __FILE__, CCTK_THORNSTRING,
                 "File \"%s\" does not exist. ABORTING", Y_e_filename);
   } else {
@@ -41,10 +41,9 @@ extern "C" void ID_TabEOS_HydroQuantities_initial_Y_e(CCTK_ARGUMENTS) {
     // Set interpolation stencil size
     const int interp_stencil_size = 5;
 
-    Ye_reader *id_ye_reader =
-        (Ye_reader *)The_Managed_Arena()->alloc(sizeof *id_ye_reader);
-    id_ye_reader->init(nrho, Y_e_file, eos_3p_tab3d->interptable->x[0],
-                       interp_stencil_size); // eg. logrho array
+    Ye_reader id_ye_reader;
+    id_ye_reader.init(nrho, Y_e_file, eos_3p_tab3d->interptable->x[0],
+                      interp_stencil_size); // eg. logrho array
 
     // Close the file
     fclose(Y_e_file);
@@ -63,7 +62,7 @@ extern "C" void ID_TabEOS_HydroQuantities_initial_Y_e(CCTK_ARGUMENTS) {
           if (rho(p.I) > rho_atm * (1 + atmo_tol)) {
             // Interpolate Y_e(rho_i) at gridpoint i
             const CCTK_REAL Y_eL =
-                id_ye_reader->interpolate_1d_quantity_as_function_of_rho(
+                id_ye_reader.interpolate_1d_quantity_as_function_of_rho(
                     interp_stencil_size, nrho, rho(p.I));
             // Finally, set the Y_e gridfunction
             Ye(p.I) = MIN(MAX(Y_eL, eos_3p_tab3d->interptable->xmin<2>()),
@@ -73,7 +72,10 @@ extern "C" void ID_TabEOS_HydroQuantities_initial_Y_e(CCTK_ARGUMENTS) {
           }
         });
 
-    The_Managed_Arena()->free(id_ye_reader);
+    // loop_all_device is asynchronous. Keep the reader's managed arrays alive
+    // until the device has finished using the by-value reader copy.
+    Gpu::synchronize();
+    id_ye_reader.release();
   }
 }
 

--- a/ID_TabEOS_HydroQuantities/src/ID_TabEOS_HydroQuantities.hxx
+++ b/ID_TabEOS_HydroQuantities/src/ID_TabEOS_HydroQuantities.hxx
@@ -21,7 +21,7 @@ private:
   int nrho;
 
 public:
-  bool interp_err{false};
+  mutable bool interp_err{false};
 
   CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
   init(int init_nrho, FILE *init_in1D, double *init_logrho_arr,
@@ -42,6 +42,13 @@ public:
     read_1dfile__set_array();
 
     return;
+  }
+
+  CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void release() {
+    The_Managed_Arena()->free(Ye_rho_arr);
+    The_Managed_Arena()->free(rho_arr);
+    Ye_rho_arr = nullptr;
+    rho_arr = nullptr;
   }
 
   CCTK_HOST CCTK_ATTRIBUTE_ALWAYS_INLINE inline void
@@ -67,7 +74,7 @@ public:
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline CCTK_REAL
   interpolate_1d_quantity_as_function_of_rho(const int interp_stencil_size,
                                              const int numlines_in_file,
-                                             const CCTK_REAL rho) {
+                                             const CCTK_REAL rho) const {
     // CCTK_REAL *restrict f_of_rho) {
 
     // First find the central interpolation stencil index:
@@ -120,7 +127,7 @@ public:
   // Find interpolation index using Bisection root-finding algorithm:
   CCTK_HOST CCTK_DEVICE CCTK_ATTRIBUTE_ALWAYS_INLINE inline int
   bisection_idx_finder(const CCTK_REAL rrbar, const int numlines_in_file,
-                       const CCTK_REAL *restrict rbar_arr) {
+                       const CCTK_REAL *restrict rbar_arr) const {
     int x1 = 0;
     int x2 = numlines_in_file - 1;
     CCTK_REAL y1 = rrbar - rbar_arr[x1];


### PR DESCRIPTION
Capture Ye_reader by value in the device closure and keep its managed interpolation arrays alive until the asynchronous GPU loop completes. Synchronize before releasing the arrays, and remove the duplicate fopen that leaked a file descriptor.

The old lifetime depended on FAB launch/reuse timing, so changing max_grid_size could change the initialized Ye field and produce asymmetric evolution.
