### PR TITLE
AsterX: prescribe staggered fields at subcycling interfaces

### DIFF
--- a/AsterX/interface.ccl
+++ b/AsterX/interface.ccl
@@ -87,9 +87,9 @@ CCTK_REAL etac TYPE=gf CENTERING={ccc} TAGS='checkpoint="no"' "Shock detector me
 
 # Note that the prolongation method and order are hard-coded and will
 # supersede parfile choices
-CCTK_REAL Avec_x TYPE=gf CENTERING={cvv} TAGS='parities={-1 +1 +1} rhs="Avec_x_rhs" prolongation_type="hermite" prolongation_order=5' "x-component of vector potential"
-CCTK_REAL Avec_y TYPE=gf CENTERING={vcv} TAGS='parities={+1 -1 +1} rhs="Avec_y_rhs" prolongation_type="hermite" prolongation_order=5' "y-component of vector potential"
-CCTK_REAL Avec_z TYPE=gf CENTERING={vvc} TAGS='parities={+1 +1 -1} rhs="Avec_z_rhs" prolongation_type="hermite" prolongation_order=5' "z-component of vector potential"
+CCTK_REAL Avec_x TYPE=gf CENTERING={cvv} TAGS='parities={-1 +1 +1} rhs="Avec_x_rhs" prolongation_type="hermite" prolongation_order=5 subcycling_prescribe_valid_cf_interface="yes"' "x-component of vector potential"
+CCTK_REAL Avec_y TYPE=gf CENTERING={vcv} TAGS='parities={+1 -1 +1} rhs="Avec_y_rhs" prolongation_type="hermite" prolongation_order=5 subcycling_prescribe_valid_cf_interface="yes"' "y-component of vector potential"
+CCTK_REAL Avec_z TYPE=gf CENTERING={vvc} TAGS='parities={+1 +1 -1} rhs="Avec_z_rhs" prolongation_type="hermite" prolongation_order=5 subcycling_prescribe_valid_cf_interface="yes"' "z-component of vector potential"
 
 CCTK_REAL Avec_x_rhs TYPE=gf CENTERING={cvv} TAGS='checkpoint="no"' "x-component of vector potential RHS"
 CCTK_REAL Avec_y_rhs TYPE=gf CENTERING={vcv} TAGS='checkpoint="no"' "y-component of vector potential RHS"
@@ -110,7 +110,7 @@ CCTK_REAL dBz_stag TYPE=gf CENTERING={ccv} TAGS='parities={-1 -1 +1} checkpoint=
 
 # ----- staggered gauge functions
 
-CCTK_REAL Psi TYPE=gf CENTERING={vvv} TAGS='rhs="Psi_rhs" prolongation_type="hermite" prolongation_order=5' "t-component of vector potential: sqrt(det(gamma_ij))*Phi"
+CCTK_REAL Psi TYPE=gf CENTERING={vvv} TAGS='rhs="Psi_rhs" prolongation_type="hermite" prolongation_order=5 subcycling_prescribe_valid_cf_interface="yes"' "t-component of vector potential: sqrt(det(gamma_ij))*Phi"
 
 CCTK_REAL Psi_rhs TYPE=gf CENTERING={vvv} TAGS='checkpoint="no"' "t-component of vector potential RHS"
 


### PR DESCRIPTION
Opt the edge-centered vector potential and vertex-centered gauge field into CarpetX's valid coarse-fine interface prescription during subcycling. These degrees of freedom are valid fine points on the geometric refinement boundary, rather than allocated ghosts, and therefore require an explicit ownership policy.