### PR TITLE
AsterX: sync saved_prims in ODESolvers_PostStep

### DIFF
--- a/AsterX/schedule.ccl
+++ b/AsterX/schedule.ccl
@@ -182,6 +182,7 @@ SCHEDULE AsterX_Sync IN ODESolvers_PostStep
 {
   LANG: C
   OPTIONS: global
+  SYNC: saved_prims
   SYNC: cons_vector Avec_x Avec_y Avec_z Psi
 } "Synchronize"
 


### PR DESCRIPTION
Add `SYNC: saved_prims` to `SCHEDULE AsterX_Sync IN ODESolvers_PostStep`  to ensure that the `saved_prims` are valid in the outer boundary and ghost zones, restriction can invalidate here.