### PR TITLE
CI: Get POWER from GitHub instead of NCSA GitLab

### DIFF
--- a/scripts/asterx.th
+++ b/scripts/asterx.th
@@ -623,7 +623,7 @@ Numerical/AEILocalInterp
 # Power -- waveform extrapolation
 !TARGET    = $ROOT/utils/Analysis
 !TYPE      = git
-!URL       = https://git.ncsa.illinois.edu/elihu/Gravitational_Waveform_Extractor.git
+!URL       = https://github.com/NCSAGravity/Gravitational_Waveform_Extractor
 !REPO_PATH = $1
 !CHECKOUT  = ./POWER
 


### PR DESCRIPTION
I've experienced CI tests failed due to an issue fetching POWER correctly. this pr is following https://github.com/EinsteinToolkit/CarpetX/pull/396