### PR TITLE
Atmo maglims

### DIFF
--- a/AsterX/param.ccl
+++ b/AsterX/param.ccl
@@ -159,6 +159,9 @@ CCTK_INT timelevels "Number of time levels for the state" STEERABLE=recover
   0:4 :: ""
 } 1
 
+BOOLEAN c2p_off_floor_strict "Shall we strictly always turn off the C2P for rho < rho_atm?" STEERABLE=always
+{
+} "yes"
 
 SHARES: EOSX
 USES CCTK_REAL poly_gamma

--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -241,9 +241,11 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType *eos_1p,
     // Check if point is below atmosphere, and if atmosphere obeys magnetization
     // limits
     const CCTK_REAL b2_atm = calc_norm(Bup, glo);
-    if ((cv.dens <= sqrt_detg * rho_atmo_cut) &&
-        (b2_atm / rho_atm <= sigma_max) &&
-        (b2_atm / (2 * press_atm) <= inv_beta_max)) {
+    const bool set_atmo = (cv.dens <= sqrt_detg * rho_atmo_cut) &&
+                          (c2p_off_floor_strict ||
+                           ((b2_atm / rho_atm <= sigma_max) &&
+                            (b2_atm / (2 * press_atm) <= inv_beta_max)));
+    if (set_atmo) {
       pv.Bvec = Bup;
       atmo.set(pv, cv, glo);
       atmo.set(pv_seeds);

--- a/AsterX/src/con2prim.cxx
+++ b/AsterX/src/con2prim.cxx
@@ -239,7 +239,8 @@ void AsterX_Con2Prim_typeEoS(CCTK_ARGUMENTS, EOSIDType *eos_1p,
     bool call_c2p = true;
 
     // Check if point is below atmosphere, and if atmosphere obeys magnetization
-    // limits
+    // limits (RPA only). Magnetization limits are currently only applied for RPA C2P, 
+    // while they are not obeyed in the other cases in the atmopshere -> TODO
     const CCTK_REAL b2_atm = calc_norm(Bup, glo);
     const bool set_atmo = (cv.dens <= sqrt_detg * rho_atmo_cut) &&
                           (c2p_off_floor_strict ||

--- a/Con2PrimFactory/src/c2p_1DEntropy.hxx
+++ b/Con2PrimFactory/src/c2p_1DEntropy.hxx
@@ -429,11 +429,7 @@ c2p_1DEntropy::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
   }
 
   // set to atmo if computed rho is below floor density
-  // and atmo obeys magnetic field limits
-  const CCTK_REAL b2_atm = calc_norm(pv.Bvec, glo);
-  if (pv.rho < atmo.rho_cut &&
-      (b2_atm / atmo.rho_atmo <= sigma_max &&
-       b2_atm / (2.0 * atmo.press_atmo) <= inv_beta_max)) {
+  if (pv.rho < atmo.rho_cut) {
     rep.set_atmo_set();
     atmo.set(pv, cv, glo);
     return;

--- a/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
+++ b/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
@@ -539,11 +539,7 @@ c2p_1DPalenzuela::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
   }
 
   // set to atmo if computed rho is below floor density
-  // and atmo obeys magnetic field limits
-  const CCTK_REAL b2_atm = calc_norm(pv.Bvec, glo);
-  if (pv.rho < atmo.rho_cut &&
-      (b2_atm / atmo.rho_atmo <= sigma_max &&
-       b2_atm / (2.0 * atmo.press_atmo) <= inv_beta_max)) {
+  if (pv.rho < atmo.rho_cut) {
     rep.set_atmo_set();
     atmo.set(pv, cv, glo);
     return;

--- a/Con2PrimFactory/src/c2p_2DNoble.hxx
+++ b/Con2PrimFactory/src/c2p_2DNoble.hxx
@@ -573,11 +573,7 @@ c2p_2DNoble::solve(const EOSType *eos_3p, prim_vars &pv, prim_vars &pv_seeds,
   }
 
   // set to atmo if computed rho is below floor density
-  // and atmo obeys magnetic field limits
-  const CCTK_REAL b2_atm = calc_norm(pv.Bvec, glo);
-  if (pv.rho < atmo.rho_cut &&
-      (b2_atm / atmo.rho_atmo <= sigma_max &&
-       b2_atm / (2.0 * atmo.press_atmo) <= inv_beta_max)) {
+  if (pv.rho < atmo.rho_cut) {
     rep.set_atmo_set();
     atmo.set(pv, cv, glo);
     return;


### PR DESCRIPTION
Add new parameter for disabling C2P when rho < rho_atmo; remove sigma_max and inv_beta_max checks from Entropy, Pal and Noble C2Ps 