### PR TITLE
Con2PrimFactory: do not reject non-positive eps

### DIFF
--- a/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
+++ b/Con2PrimFactory/src/c2p_1DPalenzuela.hxx
@@ -467,14 +467,6 @@ c2p_1DPalenzuela::solve(const EOSType *eos_3p, prim_vars &pv, cons_vars &cv,
     return;
   }
 
-  // Error out if eps is negative or zero
-  if (pv.eps <= 0.0) {
-    // set status to eps is out of range
-    rep.set_range_eps(pv.eps);
-    cv = cv_const;
-    return;
-  }
-
   if (ye_clipped) {
     rep.adjust_cons = true;
   }

--- a/Con2PrimFactory/src/c2p_2DNoble.hxx
+++ b/Con2PrimFactory/src/c2p_2DNoble.hxx
@@ -564,14 +564,6 @@ c2p_2DNoble::solve(const EOSType *eos_3p, prim_vars &pv, prim_vars &pv_seeds,
     return;
   }
 
-  // Error out if eps is negative or zero
-  if (pv.eps <= 0.0) {
-    // set status to eps is out of range
-    rep.set_range_eps(pv.eps);
-    cv = cv_const;
-    return;
-  }
-
   // set to atmo if computed rho is below floor density
   // and atmo obeys magnetic field limits
   const CCTK_REAL b2_atm = calc_norm(pv.Bvec, glo);


### PR DESCRIPTION
  ## Summary

  Remove the premature `eps <= 0` rejection from the Noble and Palenzuela
  conservative-to-primitive solvers.

  Finite non-positive values of `eps` are now passed to the existing common
  primitive floor/ceiling treatment. All other C2P convergence and physicality
  checks remain unchanged.

  ## Motivation

  Near the cylindrical blast shock, truncation error can cause an otherwise
  successful primitive recovery to produce a small non-positive specific
  internal energy.

  Previously, both Noble and the fallback Palenzuela solver immediately marked
  such a recovery as `RANGE_EPS` and returned before
  `prims_floors_and_ceilings()` could correct the thermodynamic state. Since
  both solvers encountered the same condition, AsterX treated the point as a
  complete C2P failure and reset it to atmosphere.

  Those atmosphere resets produced the pressure-floor cells visible as white
  holes around the shock. The discontinuity then caused the failure to recur
  during subsequent Runge–Kutta stages and time steps.

  With this change, the recovered state reaches the existing primitive limiting
  path. For the ideal-gas cylindrical blast, the temperature/pressure floor
  corrects the thermodynamic variables, and the conserved variables are
  recomputed consistently. The point therefore remains part of the resolved
  shock instead of being replaced by atmosphere.

  ## Validation

  A production cylindrical-blast run was performed with:

  - 200 × 200 grid
  - HLLE fluxes
  - MINMOD reconstruction
  - RK4
  - FluxCT
  - final time `t = 4.05`

  Results after this change:

  - zero C2P failure messages
  - zero interior cells with `P < 1e-5`
  - minimum interior pressure: approximately `2.16e-5`
  - the large white pressure-floor holes are absent
  - the shock remains continuous through the final time